### PR TITLE
Add: Error handler for 500 server errors (Fixes #6)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 #app/__init__.py
-from flask import Flask
+from flask import Flask, render_template
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from config import config
@@ -38,6 +38,12 @@ def create_app(config_name = 'default'):
     app.register_blueprint(main)
     app.register_blueprint(admin, url_prefix='/admin')
     app.register_blueprint(auth, url_prefix='/auth')
+
+        # Error handlers
+    @app.errorhandler(500)
+    def internal_error(error):
+        """Handle 500 errors"""
+        return render_template('errors/500.html'), 500
 
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
## Description
This PR adds the Flask error handler for 500 server errors to properly render the custom error page created in PR #7.

## Changes Made
- **Modified** `app/__init__.py` to:
  - Import `render_template` from Flask
  - Add `@app.errorhandler(500)` decorator to handle 500 errors
  - Return the custom 500 error template

## Related Work
This PR complements PR #7 which adds the custom 500 error page template (`app/templates/errors/500.html`).

## Testing
1. With this change, when a 500 error occurs, Flask will now render the custom error page instead of the default Flask error page
2. The error page will display the user-friendly message without exposing technical details

Fixes #6