### PR TITLE
fixed broken view-details-btn on product details page

### DIFF
--- a/app/templates/main/product_detail.html
+++ b/app/templates/main/product_detail.html
@@ -282,7 +282,7 @@
                             <p class="product-stock out-of-stock">✗ Out of Stock</p>
                         {% endif %}
                         
-                        <a href="/product/{{ p.id }}" class="btn btn-block">
+                        <a href="/products/{{ p.id }}" class="btn btn-block">
                             View Details
                         </a>
                     </div>
@@ -338,7 +338,7 @@
                             <p class="product-stock out-of-stock">✗ Out of Stock</p>
                         {% endif %}
                         
-                        <a href="/product/{{ p.id }}" class="btn btn-block">
+                        <a href="/products/{{ p.id }}" class="btn btn-block">
                             View Details
                         </a>
                     </div>


### PR DESCRIPTION
# 🐞 Pull Request: Fix "View Details" Button in Recently Viewed Products and You may like this Sections.

### ✅ Summary
This PR fixes the broken **View Details** button in the both Recently Viewed Products and You may like this sections.

### 🔧 Changes
- Corrected the product detail URL used in the button
- Ensured the correct product ID/slug is passed

### 🎯 Purpose
Restores proper navigation from recently viewed products to their detail pages.

Closes #100 
